### PR TITLE
Use the EmptyTree for macro return.

### DIFF
--- a/macros/src/main/scala/FIXME.scala
+++ b/macros/src/main/scala/FIXME.scala
@@ -23,7 +23,7 @@ object FIXME {
     } catch {
       case any: Exception => c.abort(c.enclosingPosition, "Expected format: 'yyyy/MM/dd: message'")
     }
-    reify()
+    c.Expr[Any](EmptyTree)
   }
 }
 


### PR DESCRIPTION
Not an ideal solution but feels better than the empty reify.
